### PR TITLE
feat: apply time sync and journald setters

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,7 @@ fi
 
 PI_MODEL=$(tr -d '\0' < /proc/device-tree/model 2>/dev/null || echo "")
 
+# Configure host time settings and journald storage limits
 set_timezone Europe/Amsterdam
 set_time_sync
 set_journald_limits

--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,8 @@ fi
 PI_MODEL=$(tr -d '\0' < /proc/device-tree/model 2>/dev/null || echo "")
 
 set_timezone Europe/Amsterdam
+set_time_sync
+set_journald_limits
 
 echo -e "${BLUE}►► Applying video and boot options...${NC}"
 if ! file_backup "$CMDLINE_FILE"; then


### PR DESCRIPTION
## Summary
- call `set_time_sync` during installation to enable system time synchronization where supported
- call `set_journald_limits` to apply the default journald storage limits from `bash-functions`
- use the smaller helpers merged in oszuidwest/bash-functions#15 instead of the earlier broad hardening baseline

## Validation
- `bash -n` on the modified installer script
- `shellcheck` on the modified installer script
- `git diff --check`